### PR TITLE
Missing `{` after `if (num % 90 == 0 && num % 180 != 0)`

### DIFF
--- a/src/simplejavacalculator/Calculator.java
+++ b/src/simplejavacalculator/Calculator.java
@@ -103,7 +103,7 @@ public class Calculator {
             if (num == 0 || num % 180 == 0) {
                 return 0.0;
             }
-            if (num % 90 == 0 && num % 180 != 0)
+            if (num % 90 == 0 && num % 180 != 0) {
                 return NaN;
             }
 


### PR DESCRIPTION
You forgot to put the  `{` after `if (num % 90 == 0 && num % 180 != 0)` under `calculateMono` method. It is causing errors. Others might not be able to see that there is just missing `{` there to correct the errors.