### PR TITLE
Fix test script error using Math.toDegrees()

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 # Mac OS System
 .DS_Store*
 ._*
+/bin/

--- a/.project
+++ b/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>assignment3_Simple-Java-Calculator</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/src/simplejavacalculatorTest/CalculatorTest.java
+++ b/src/simplejavacalculatorTest/CalculatorTest.java
@@ -82,19 +82,19 @@ class CalculatorTest {
 	@Test
 	void CalculateMonoSinTest() {
 		Calculator calculator = new Calculator();
-		Assertions.assertEquals(0.5, calculator.calculateMono(Calculator.MonoOperatorModes.sin, java.lang.Math.PI / 6), 0.0000000001);
+		Assertions.assertEquals(0.5, calculator.calculateMono(Calculator.MonoOperatorModes.sin, Math.toDegrees(java.lang.Math.PI) / 6), 0.0000000001);
 	}
 	
 	@Test
 	void CalculateMonoCosTest() {
 		Calculator calculator = new Calculator();
-		Assertions.assertEquals(0.5, calculator.calculateMono(Calculator.MonoOperatorModes.cos, java.lang.Math.PI / 3), 0.0000000001);
+		Assertions.assertEquals(0.5, calculator.calculateMono(Calculator.MonoOperatorModes.cos, Math.toDegrees(java.lang.Math.PI) / 3), 0.0000000001);
 	}
 	
 	@Test
 	void CalculateMonoTanTest() {
 		Calculator calculator = new Calculator();
-		Assertions.assertEquals(1.0, calculator.calculateMono(Calculator.MonoOperatorModes.tan, java.lang.Math.PI / 4), 0.0000000001);
+		Assertions.assertEquals(1.0, calculator.calculateMono(Calculator.MonoOperatorModes.tan, Math.toDegrees(java.lang.Math.PI) / 4), 0.0000000001);
 	}
 	
 	@Test


### PR DESCRIPTION
Math.toDegrees() function is applied to test cases CalculateMonoSinTest(), void CalculateMonoCosTest() and void CalculateMonoTanTest().